### PR TITLE
Allow wider range of camera rotation in Mk3 shuttle IVA

### DIFF
--- a/GameData/DE_IVAExtension/Spaces/DE_MK3_Cockpit_Int.cfg
+++ b/GameData/DE_IVAExtension/Spaces/DE_MK3_Cockpit_Int.cfg
@@ -17,6 +17,14 @@ INTERNAL
 	}
 	MODULE
 	{
+		name = InternalCameraTargetHelper
+	}
+	MODULE
+	{
+		name = JSISetInternalCameraFOV
+	}
+	MODULE
+	{
 		name = InternalCameraSwitch
 		colliderTransformName = focus_W1
 		cameraTransformName = Camera_Focus_W1
@@ -75,8 +83,12 @@ INTERNAL
 		seatTransformName = Seat_Left
 		portraitCameraName = Camera_Left
 		allowCrewHelmet = false
-		kerbalEyeOffset = 0, 0.02, 0
+		kerbalEyeOffset = 0, 0.0, -0.1
 		displayseatName = #autoLoc_6002193
+		hideKerbal = all
+		maxRot = 180
+		minPitch = -110
+		maxPitch = 110
 	}
 	MODULE
 	{
@@ -84,8 +96,12 @@ INTERNAL
 		seatTransformName = Seat_Right
 		portraitCameraName = Camera_Right
 		allowCrewHelmet = false
-		kerbalEyeOffset = 0, 0.02, 0
+		kerbalEyeOffset = 0, 0.0, -0.1
 		displayseatName = #autoLoc_6002192
+		hideKerbal = all
+		maxRot = 180
+		minPitch = -110
+		maxPitch = 110
 	}
 	MODULE
 	{
@@ -96,6 +112,10 @@ INTERNAL
 		kerbalEyeOffset = 0, 0.02, 0
 		displayseatName = #autoLoc_6002195
 		displayseatIndex = 2
+		hideKerbal = all
+		maxRot = 180
+		minPitch = -110
+		maxPitch = 110
 	}
 	MODULE
 	{
@@ -106,6 +126,10 @@ INTERNAL
 		kerbalEyeOffset = 0, 0.02, 0
 		displayseatName = #autoLoc_6002196
 		displayseatIndex = 2
+		hideKerbal = all
+		maxRot = 180
+		minPitch = -110
+		maxPitch = 110
 	}
 	PROP
 	{


### PR DESCRIPTION
## Why?
The side screens and bottom screens of the Mk3 shuttle cannot be fully zoomed to because of the camera rotation/pitch limits.

## Changes
- Extend to -180/180 horizontally (you can see fully behind you)
- Extend to -110/110 vertically
- Hide entire Kerbal body (of the current seat)
- Slight lowering/backing of the camera

These changes affect RasterPropMonitor only.

Tested both with and without MAS:
- With RPM only: Camera rotation range is extended
- With MAS only: No-op. Default rotation bounds

Note: There is an open issue in MAS to add support for `JSISetInternalCameraFOV`, so when that is completed these changes should work on MAS as well
https://github.com/MOARdV/AvionicsSystems/issues/353

## Demo
![image](https://github.com/user-attachments/assets/17959567-d497-4dbd-b190-5c7e7d6c5506)

![image](https://github.com/user-attachments/assets/a3a4d2b2-9eb7-4b71-bcaa-309daa468e48)

![image](https://github.com/user-attachments/assets/0e8a0c0a-0b79-4766-b61f-2a9bccb9bfb6)
